### PR TITLE
Add reproman and cuda library path

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,8 +44,7 @@ RUN conda install --yes datalad rclone 'h5py>3.3=mpi*' ipykernel zarr blosc \
   && pip install --no-cache-dir jupytext nbgitpuller datalad-container \
      datalad-osf nibabel nilearn dipy pybids pynidm pydra-ml reproschema reproman nda-tools \
      'pydra>=0.17' plotly itkwidgets==0.32.0 hdf5plugin s3fs datalad-neuroimaging pyontutils \
-     PyMARE  gower \
-     git+https://github.com/ReproNim/neurodocker.git@60e41158 \
+     PyMARE  gower neurodocker \
   && conda clean --all -f -y && rm -rf /tmp/*
 
 # git+https://github.com/ReproNim/reproman.git@0ff92665

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,7 @@ RUN conda install --yes datalad rclone 'h5py>3.3=mpi*' ipykernel zarr blosc \
   && wget --quiet https://raw.githubusercontent.com/DanielDent/git-annex-remote-rclone/v0.6/git-annex-remote-rclone \
   && chmod +x git-annex-remote-rclone && mv git-annex-remote-rclone /opt/conda/bin \
   && pip install --no-cache-dir jupytext nbgitpuller datalad-container \
-     datalad-osf nibabel nilearn dipy pybids pynidm pydra-ml reproschema nda-tools \
+     datalad-osf nibabel nilearn dipy pybids pynidm pydra-ml reproschema reproman nda-tools \
      'pydra>=0.17' plotly itkwidgets==0.32.0 hdf5plugin s3fs datalad-neuroimaging pyontutils \
      PyMARE  gower \
      git+https://github.com/ReproNim/neurodocker.git@60e41158 \

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -45,8 +45,7 @@ RUN conda install --yes datalad rclone 'h5py>3.3=mpi*' ipykernel zarr blosc \
   && pip install --no-cache-dir jupytext nbgitpuller datalad-container \
      datalad-osf nibabel nilearn dipy pybids pynidm pydra-ml reproschema reproman nda-tools \
      'pydra>=0.17' plotly itkwidgets==0.32.0 hdf5plugin s3fs datalad-neuroimaging pyontutils \
-     PyMARE  gower \
-     git+https://github.com/ReproNim/neurodocker.git@60e41158 \
+     PyMARE  gower neurodocker \
   && conda clean --all -f -y && rm -rf /tmp/*
 
 # git+https://github.com/ReproNim/reproman.git@0ff92665

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -97,3 +97,5 @@ RUN cd /opt/extras && \
 
 RUN mamba install --yes -c rapidsai-nightly jupyterlab-nvdashboard && \
     conda clean --all -f -y && rm -rf /tmp/*
+    
+ENV LD_LIBRARY_PATH /opt/conda/lib/

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -43,7 +43,7 @@ RUN conda install --yes datalad rclone 'h5py>3.3=mpi*' ipykernel zarr blosc \
   && wget --quiet https://raw.githubusercontent.com/DanielDent/git-annex-remote-rclone/v0.6/git-annex-remote-rclone \
   && chmod +x git-annex-remote-rclone && mv git-annex-remote-rclone /opt/conda/bin \
   && pip install --no-cache-dir jupytext nbgitpuller datalad-container \
-     datalad-osf nibabel nilearn dipy pybids pynidm pydra-ml reproschema nda-tools \
+     datalad-osf nibabel nilearn dipy pybids pynidm pydra-ml reproschema reproman nda-tools \
      'pydra>=0.17' plotly itkwidgets==0.32.0 hdf5plugin s3fs datalad-neuroimaging pyontutils \
      PyMARE  gower \
      git+https://github.com/ReproNim/neurodocker.git@60e41158 \


### PR DESCRIPTION
This PR adds reproman to the list of pip installs. It also installs neurodocker from pypi instead of GitHub.